### PR TITLE
Fixed Sidebar Height in responsive manner

### DIFF
--- a/app/components/Sidebar/index.js
+++ b/app/components/Sidebar/index.js
@@ -9,6 +9,9 @@ import useViewer from 'Hooks/useViewer';
 import './style.scss';
 
 const navigation = ({ viewer }) => {
+  let viewingHeight = window.innerHeight * 0.01;
+  document.documentElement.style.setProperty('--vh', `${viewingHeight}px`);
+
   const features = extractMap(viewer, {
     key: 'features',
     label: 'name',

--- a/app/components/Sidebar/style.scss
+++ b/app/components/Sidebar/style.scss
@@ -1,4 +1,5 @@
 .main-menu {
-  max-height: calc(100vh - 120px);
+  height: 100vh; /* Fallback for browsers that do not support Custom Properties */
+  height: calc(var(--vh, 1vh) * 100);
   overflow-y: auto;
 }


### PR DESCRIPTION
Fixes #28 

## Before 
![image](https://user-images.githubusercontent.com/35633575/82151306-93b79180-9878-11ea-9f9f-869e3d002ab5.png)

## After
### Web
<img width="924" alt="Screenshot 2020-05-17 at 7 50 32 PM" src="https://user-images.githubusercontent.com/35633575/82151329-a4680780-9878-11ea-89c2-51e5fb500a2e.png">

### Mobile
<img width="924" alt="Screenshot 2020-05-17 at 7 50 39 PM" src="https://user-images.githubusercontent.com/35633575/82151330-a631cb00-9878-11ea-8393-abbf94f106fb.png">
