### PR TITLE
Build in Windows fails as it expects hexadecimal after '\u' fixes #68

### DIFF
--- a/api/bin/utils.js
+++ b/api/bin/utils.js
@@ -25,13 +25,15 @@ export const getDirContents = (dir) =>
     return contents;
   }, {});
 
+const getRawString = (str) => String.raw`${str}`;
+
 const convertMapToString = (map) =>
   `{
     ${Object.keys(map).reduce(
       (str, key) => `${str}
         ${key}: ${
         typeof map[key] === 'string'
-          ? `require('${map[key]}').default`
+          ? `require('${getRawString(map[key])}').default`
           : convertMapToString(map[key])
       },
       `,


### PR DESCRIPTION
@hereisnaman please review, This PR will resolve the build problem in Windows, which fails as it expects hexadecimal after '\u' fixes resolves #68 #76