### PR TITLE
[Impersonation] cookie path set to root(/) fix #46

### DIFF
--- a/app/modals/Impersonate/index.js
+++ b/app/modals/Impersonate/index.js
@@ -10,7 +10,7 @@ const Impersonate = ({ onClose }) => {
 
   const handleImpersonate = () => {
     const user_id = user.id;
-    document.cookie = `iuid=${user_id}`;
+    document.cookie = `iuid=${user_id};path=/`;
     window.location = router.pathname;
   };
 
@@ -20,7 +20,7 @@ const Impersonate = ({ onClose }) => {
       <ModalBody>
         <Form className="row">
           <Form.Group className="has-float-label mb-4 col-12">
-            <Form.Label>Impersonate</Form.Label>
+            <Form.Label>User</Form.Label>
             <UserSelect
               name="User"
               placeholder="User"

--- a/app/styles/_gogo.style.scss
+++ b/app/styles/_gogo.style.scss
@@ -4014,6 +4014,7 @@ select.form-control:not([size]):not([multiple]) {
 .react-select .react-select__single-value,
 .react-select .react-select__multi-value__label {
   color: $primary-color;
+  display: contents;
 }
 
 .react-select .react-select__dropdown-indicator,


### PR DESCRIPTION
This PR will 
- set cookie path to /(root)
- changed label to User
- change CSS padding-bottom to 0.9rem, which result in modal select padding to increase everywhere.

![test](https://user-images.githubusercontent.com/39825643/82536217-c4901300-9b65-11ea-8b00-d1fddc20835a.gif)

@hereisnaman 
**Potential Problem** : (In Add Event as well invites and zoom account select padding got increased)

![Screenshot from 2020-05-21 13-25-21](https://user-images.githubusercontent.com/39825643/82536783-9fe86b00-9b66-11ea-98c8-b273771e5742.png)

![inhere](https://user-images.githubusercontent.com/39825643/82536730-8ba46e00-9b66-11ea-9b0a-f02258528015.png)
