### PR TITLE
accountAvailability-Dataloader: use findAll instead of findOne to imp…

### DIFF
--- a/api/graphql/query/CalendarEventInvite/availability.js
+++ b/api/graphql/query/CalendarEventInvite/availability.js
@@ -6,7 +6,7 @@ const availability = async (parent, _args, { loaders }) => {
   return loaders.userAvailability.load({
     user_id: parent.user_id,
     dateTimeRange: { start_at: event.start_at, end_at: event.end_at },
-    exculdeEvents: [event.id],
+    excludeEvents: [event.id],
   });
 };
 

--- a/api/graphql/query/User/availability.js
+++ b/api/graphql/query/User/availability.js
@@ -1,8 +1,11 @@
 const availability = async (parent, { dateTimeRange }, { loaders }) =>
   loaders.userAvailability.load({
     user_id: parent.id,
-    dateTimeRange,
-    exculdeEvents: [],
+    dateTimeRange: {
+      start_at: new Date(dateTimeRange.start_at),
+      end_at: new Date(dateTimeRange.end_at),
+    },
+    excludeEvent: [],
   });
 
 export default availability;


### PR DESCRIPTION

## Issue
fixes: #7 

## Solution
PR #79 : `findAll` should've been used in the dataloader to improve the performance

## Checklist
*PR will only be reviewed if the checklist is completed*
- [x] I have done extensive testing for my changes.
- [x] I have self-reviewed my PR and removed all un-necessary changes.
- [x] My changes works well on both desktop and mobile environments.
- [x] I have made sure that my changes solves the actual problem mentioned in the issue.
- [x] The PR contains only 1 commit and have been updated with `master`.
