### PR TITLE
Graphql schema build removes spaces in file paths fixes #62

### DIFF
--- a/api/bin/utils.js
+++ b/api/bin/utils.js
@@ -42,7 +42,7 @@ const convertMapToString = (map) =>
   }`;
 
 export const transformMap = (map) =>
-  `export default ${convertMapToString(map).replace(/\s/g, '')}`;
+  `export default ${convertMapToString(map)}`;
 
 export const transformTypeDefs = (typeDefs) =>
   typeDefs.join('\n').replace(/(\r\n|\r|\n){2,}/g, '$1\n');


### PR DESCRIPTION
## Issue
fixes: #62 

## Solution
- don't remove space using regex inside transformMap.

## Working/Testing Screenshots - Fine
![aloha](https://user-images.githubusercontent.com/39825643/82747469-a66d2180-9db6-11ea-9fdc-028dc4f7c56d.png)
- 

## Checklist
*PR will only be reviewed if the checklist is completed*
- [x] I have done extensive testing for my changes.
- [x] I have self-reviewed my PR and removed all un-necessary changes.
- [x] My changes works well on both desktop and mobile environments.
- [x] I have made sure that my changes solves the actual problem mentioned in the issue.
- [x] The PR contains only 1 commit and have been updated with `master`.
