### PR TITLE
app menu section does not scroll on mobile fix #101

### DIFF
--- a/app/components/AppMenu/index.js
+++ b/app/components/AppMenu/index.js
@@ -7,7 +7,7 @@ const AppMenu = ({ children }) => (
   <div className="app-menu">
     <PerfectScrollbar
       id="app-menu-scroll-container"
-      options={{ suppressScrollX: true, wheelPropagation: false }}>
+      options={{ suppressScrollX: true, wheelPropagation: true }}>
       <div className="scroll">
         <div className="scrollbar-container overflow-auto">
           <div className="p-4">

--- a/app/styles/_custom.scss
+++ b/app/styles/_custom.scss
@@ -22,6 +22,9 @@
     width: 100% !important;
     transform: none !important;
     margin: 1rem 0 !important;
+    .scroll {
+      max-height: 100vh;
+    }
   }
 }
 .color-box {


### PR DESCRIPTION
## Issue
fixes: #101 

## Solution
- Added max-height of 100vh to the app menu, so that we can scroll through large content
- set wheelPropogation to true for a smooth transition from once scroll place to other
## Screenshots (Desktop)& (Mobile)
![a](https://user-images.githubusercontent.com/39825643/82786907-10eb9380-9e83-11ea-8a70-6dc4b12671c8.gif)

## Checklist
*PR will only be reviewed if the checklist is completed*
- [x] I have done extensive testing for my changes.
-  [x] I have self-reviewed my PR and removed all unnecessary changes.
- [x] My changes works well on both desktop and mobile environments.
- [x] I have made sure that my changes solve the actual problem mentioned in the issue.
- [x] The PR contains only 1 commit and have been updated with `master`.
