### PR TITLE
onchange replaces onClick to solve failed prop type fix #126

### DIFF
--- a/app/components/Events/Form.js
+++ b/app/components/Events/Form.js
@@ -76,8 +76,8 @@ const EventForm = memo(
             name="type"
             placeholder="Select Event Type"
             value={getEventTypeLabel(type)}
-            onChange={({ value,title,color }) =>
-              setType({ label:title, value, color })
+            onChange={({ value, title, color }) =>
+              setType({ label: title, value, color })
             }
             options={useMemo(() => types.map(getEventTypeOption), [types])}
           />
@@ -158,7 +158,7 @@ const EventForm = memo(
             name="public"
             checked={isPublic}
             value={isPublic}
-            onClick={() => setIsPublic(!isPublic)}
+            onChange={() => setIsPublic(!isPublic)}
           />
         </Form.Group>
       </Form>


### PR DESCRIPTION
## Issue
fixes: #126 

## Solution
`onChange` prop must be provided if used checked to make it controlled component

## Checklist
*PR will only be reviewed if the checklist is completed*
- [x] I have done extensive testing for my changes.
- [x] I have self-reviewed my PR and removed all unnecessary changes.
- [x] My changes works well on both desktop and mobile environments.
- [x] I have made sure that my changes solve the actual problem mentioned in the issue.
- [x] The PR contains only 1 commit and have been updated with `master`.
