### PR TITLE
WIP: Add event page

### DIFF
--- a/api/graphql/base/EntityResolver.js
+++ b/api/graphql/base/EntityResolver.js
@@ -1,11 +1,17 @@
 import BaseResolver from './Resolver';
+import { UserInputError } from 'apollo-server-micro';
 
 class EntityResolver extends BaseResolver {
   resolve = async () =>
-    this.model.findOne({
-      where: { id: Number(this.args.id) },
-      ...((await this.query?.call(this)) || {}),
-    });
+    this.model
+      .findOne({
+        where: { id: Number(this.args.id), slug: String(this.args.slug) },
+        ...((await this.query?.call(this)) || {}),
+      })
+      .then(console.log(this.args))
+      .catch((err) => {
+        throw new UserInputError(err);
+      });
 }
 
 export default EntityResolver;

--- a/api/graphql/directives/protected.js
+++ b/api/graphql/directives/protected.js
@@ -14,6 +14,16 @@ export default class ProtetedDirective extends SchemaDirectiveVisitor {
         field._parentEntity ||
         camelcase(info.parentType.name);
 
+      const postExecution = _this.args.post_execution;
+
+      if (postExecution === true) {
+        const entity = resolve.call(this, parent, _args, ctx, info);
+
+        return await AuthPolicy.can(ctx.viewer)
+          .perform(`${entity}:${field.name}:read`)
+          .on(parent);
+      }
+
       if (
         await AuthPolicy.can(ctx.viewer)
           .perform(`${entityName}:${field.name}:read`)

--- a/api/graphql/directives/type.graphql
+++ b/api/graphql/directives/type.graphql
@@ -1,5 +1,8 @@
 directive @define(entity: String = "") on OBJECT
 
-directive @protected(entity: String = "") on FIELD_DEFINITION
+directive @protected(
+  entity: String = ""
+  post_execution: Boolean = true
+) on FIELD_DEFINITION
 
 directive @requireFeature(name: String = "") on FIELD_DEFINITION

--- a/api/graphql/query/CalendarEvent/type.graphql
+++ b/api/graphql/query/CalendarEvent/type.graphql
@@ -11,7 +11,7 @@ enum CalendarEventType {
 
 type CalendarEventTypeColorMap {
   name: String!
-  title:String!
+  title: String!
   color: String!
 }
 
@@ -44,7 +44,7 @@ type CalendarEventConnection {
 
 extend type Query {
   #TODO(naman): handle authorization
-  event(id: ID!): CalendarEvent
+  event(id: ID, slug: String = ""): CalendarEvent
 
   events(
     limit: Int

--- a/api/services/AuthorizationPolicy/index.js
+++ b/api/services/AuthorizationPolicy/index.js
@@ -72,6 +72,11 @@ policy.include('calendarEvent', (p) => {
     ({ viewer, entity: event }) =>
       isOrganiser(event, viewer) || isAdmin(viewer),
   );
+  p.register('read', ({ viewer, entity: event }) => {
+    if (event.is_public) return true;
+
+    return isMember(viewer) || isOrganiser(event, viewer);
+  });
 
   p.include(
     [

--- a/app/modals/ViewEvent/index.js
+++ b/app/modals/ViewEvent/index.js
@@ -25,7 +25,7 @@ const ViewEvent = ({ id, onClose, event, startPolling, stopPolling }) => {
     );
   }
 
-  const queryData = { query: QUERY, variables: { id } };
+  const queryData = { query: QUERY, variables: { id, slug } };
 
   return (
     <Modal isOpen={true} size="sm" toggle={() => onClose()}>
@@ -37,7 +37,7 @@ const ViewEvent = ({ id, onClose, event, startPolling, stopPolling }) => {
 export default createPage({
   Component: ViewEvent,
   query: QUERY,
-  variables: ({ id }) => ({ id }),
+  variables: ({ id, slug }) => ({ id, slug }),
   LoaderComponent: ({ onClose }) => (
     <Modal isOpen={true} size="sm" toggle={() => onClose()}>
       <ModalBody>

--- a/app/modals/ViewEvent/query.graphql
+++ b/app/modals/ViewEvent/query.graphql
@@ -3,8 +3,8 @@
 #import "../../fragments/eventInvite.graphql"
 #import "../../fragments/resource.graphql"
 
-query ViewEventQuery($id: ID!) {
-  event(id: $id) {
+query ViewEventQuery($id: ID, $slug: slug) {
+  event(id: $id, slug: $slug) {
     ...EventFragment
     organiser {
       ...UserFragment


### PR DESCRIPTION
- [x] Update Protected directive to accept a boolean argument post_execution. If the arg is true then check for the authorization after calling the resolver and pass the value returned by the resolver as entity while calling the authorization policy.
- [x]  Mark the root query field event as protected and pass post_execution as true.
- [x]  Update AuthPolicy to allow read by not logged in users on calendar event if the is_public for the event is true. Otherwise restrict the read access to Members and event organisers.
- [x]  Update EntityResolver to check if the model has a slug field and auto update the query to find 1 item based on if either theargs.id matches the id or args.slug matches the slug. Also throw UserInputError if both id and slug are undefined.
- [x]  Update the root level query field event to have 2 optional args id and slug.
- [ ]  Add a new page /events/[event_id_or_slug].js. On page open the ViewEvent modal and pass the url param as id and slug. Update the modal to accept both id and slug and pass it to the query.
- [ ]  Do complete testing of the features for all the user roles and logged out view.

## Checklist
- [ ] I have done extensive testing for my changes.
- [ ] I have self-reviewed my PR and removed all un-necessary changes.
- [ ] My changes works well on both desktop and mobile environments.
- [ ] I have made sure that my changes solves the actual problem mentioned in the issue.
- [ ] The PR contains only 1 commit and have been updated with `master`.
