### PR TITLE
bugFix: BaseConnection - fix edge.cursor mismatch. fix #32

### DIFF
--- a/api/config/db.js
+++ b/api/config/db.js
@@ -12,7 +12,7 @@ module.exports = {
     pool: { maxConnections: 5, maxIdleTime: 30 },
     language: 'en',
     alter: false,
-    logging: true,
+    logging: false,
     define: {
       underscored: true,
       underscoredAll: true,

--- a/api/graphql/base/ConnectionResolver.js
+++ b/api/graphql/base/ConnectionResolver.js
@@ -34,7 +34,7 @@ export default class BaseConnectionResolver extends BaseResolver {
     return {
       edges: results.map((node) => ({
         node,
-        cursor: Buffer.from(JSON.stringify(node.id)).toString('base64'),
+        cursor: Buffer.from(JSON.stringify([node.id])).toString('base64'),
       })),
       pageInfo: {
         startCursor: cursors.before,

--- a/api/routes/graphql/index.js
+++ b/api/routes/graphql/index.js
@@ -14,9 +14,14 @@ const server = new ApolloServer({
     loaders: {
       userAvailability: User.getAvailabilityLoader(),
       eventInviteStatus: CalendarEventInvite.getStatusLoader(),
-      zoomAccountAvailability: ZoomAccount.getAvailabilityLoader()
+      zoomAccountAvailability: ZoomAccount.getAvailabilityLoader(),
     },
   }),
+  playground: {
+    settings: {
+      'request.credentials': 'include',
+    },
+  },
 });
 
 export const config = { api: { bodyParser: false } };


### PR DESCRIPTION
## Issue
fixes: #32

## Solution
- an array of id is required to be passed while encoding the cursor to generate cursor. 

### Result : (Validation) 
![a](https://user-images.githubusercontent.com/39825643/84351198-7ad0a080-abd8-11ea-856a-537de42d4c17.png)

## Checklist
*PR will only be reviewed if the checklist is completed*
- [x] I have done extensive testing for my changes.
- [x] I have self-reviewed my PR and removed all un-necessary changes.
- [x] My changes works well on both desktop and mobile environments.
- [x] I have made sure that my changes solves the actual problem mentioned in the issue.
- [x] The PR contains only 1 commit and have been updated with `master`.
